### PR TITLE
:recycle: Many fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.30)
 
 # Generate compile commands for anyone using our libraries.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 project(strong_ptr LANGUAGES CXX)
 
@@ -65,10 +66,10 @@ else()
         tests/unit_test.cppm
         PRIVATE
         tests/main.test.cpp
-        tests/optional_ptr.test.cpp
-        tests/enable_from_this.test.cpp
         tests/strong_ptr.test.cpp
+        tests/optional_ptr.test.cpp
         tests/weak_ptr.test.cpp
+        tests/enable_from_this.test.cpp
         tests/mixins.test.cpp
     )
     target_compile_features(strong_ptr_unit_test PUBLIC cxx_std_23)

--- a/tests/optional_ptr.test.cpp
+++ b/tests/optional_ptr.test.cpp
@@ -51,7 +51,7 @@ boost::ut::suite<"optional_ptr_conversion_test"> optional_ptr_conversion_test =
     "conversion_with_empty_optional"_test = [&] {
       optional_ptr<test_class> empty;
 
-      expect(throws<mem::bad_optional_ptr_access>([&] {
+      expect(throws<mem::nullptr_access>([&] {
         strong_ptr<test_class> converted = empty;  // Should throw
       }));
     };
@@ -170,10 +170,10 @@ boost::ut::suite<"optional_ptr_test"> optional_ptr_test =
 
       // Test exception on accessing null optional
       optional_ptr<test_class> empty;
-      expect(throws<mem::bad_optional_ptr_access>(
+      expect(throws<mem::nullptr_access>(
         [&] { [[maybe_unused]] auto _ = empty->value(); }))
         << "Accessing null optional with arrow operator should throw\n";
-      expect(throws<mem::bad_optional_ptr_access>(
+      expect(throws<mem::nullptr_access>(
         [&] { [[maybe_unused]] auto _ = (*empty).value(); }))
         << "Accessing null optional with dereference operator should throw\n";
     };
@@ -218,27 +218,6 @@ boost::ut::suite<"optional_ptr_test"> optional_ptr_test =
         << "First derived should lose shared ownership\n";
       expect(that % 2 == derived2.use_count())
         << "Second derived should gain shared ownership\n";
-    };
-
-    "weak_ptr_lock"_test = [&] {
-      weak_ptr<test_class> weak;
-      {
-        // Test creating an optional_ptr through weak_ptr::lock()
-        auto strong = make_strong_ptr<test_class>(test_allocator, 42);
-        weak = strong;
-
-        auto locked = weak.lock();
-        expect(that % true == bool(locked))
-          << "Locked weak_ptr should be valid\n";
-        expect(that % 42 == locked->value()) << "Value should match original\n";
-        expect(that % 2 == strong.use_count())
-          << "Should share ownership with original\n";
-      }
-
-      // Lock should now fail
-      auto locked2 = weak.lock();
-      expect(that % false == bool(locked2))
-        << "Locked expired weak_ptr should be empty\n";
     };
 
     "equality"_test =

--- a/tests/unit_test.cppm
+++ b/tests/unit_test.cppm
@@ -14,13 +14,14 @@
 
 module;
 
+#include <array>
 #include <memory_resource>
 
 export module strong_ptr_unit_test;
 
-import strong_ptr;
+export import strong_ptr;
 
-export namespace mem {
+export namespace mem::inline v1 {
 // Base class for testing polymorphism
 class base_class
 {
@@ -212,4 +213,4 @@ std::array<std::byte, 4096 * 16> buffer{};
 std::pmr::monotonic_buffer_resource test_resource{ buffer.data(),
                                                    buffer.size() };
 std::pmr::polymorphic_allocator<> test_allocator{ &test_resource };
-}  // namespace mem
+}  // namespace mem::inline v1

--- a/tests/weak_ptr.test.cpp
+++ b/tests/weak_ptr.test.cpp
@@ -130,33 +130,4 @@ boost::ut::suite<"weak_ptr_test"> weak_ptr_test = []() {
         << "Locking expired weak_ptr should return null optional\n";
     };
 };
-
-// bad_weak_ptr exception test suite
-boost::ut::suite<"bad_weak_ptr_test"> bad_weak_ptr_test = []() {
-  using namespace boost::ut;
-
-  "exception_type"_test = [&] {
-    // Test that bad_weak_ptr is properly derived from mem::exception
-    static_assert(std::is_base_of_v<mem::exception, mem::bad_weak_ptr>);
-
-    // Test construction
-    expect(nothrow([&] {
-      mem::bad_weak_ptr ex(nullptr);
-      // Should construct without throwing
-    }));
-  };
-
-  "thrown_from_enable_strong_from_this"_test = [&] {
-    // This test would require creating an unmanaged object, which is
-    // prevented by strong_ptr_only. The exception handling is tested
-    // indirectly through the normal usage patterns.
-
-    // Just verify that normal usage doesn't throw
-    auto obj = make_strong_ptr<self_aware_class>(test_allocator, 42);
-    expect(nothrow([&] {
-      auto self = obj->strong_from_this();
-      expect(that % 42 == self->value());
-    }));
-  };
-};
 }  // namespace mem


### PR DESCRIPTION
This commit includes a variety of fixes and improvements to the strong_ptr library:

- Migrate free functions (add_ref, release, add_weak, release_weak) into ref_info object API.
- Remove detail namespace for improved code clarity
- Split monolithic test suite into focused files
  - enable_from_this.test.cpp,
  - mixins.test.cpp
  - optional_ptr.test.cpp
  - weak_ptr.test.cpp
- Add shared unit_test.cppm module for test utilities
- Update CMake to 3.30 with compiler warnings and address sanitizer for tests
- Update conanfile description and boost-ext-ut version
- Update code comments for clarity
- Refactor enable_strong_from_this to work with rc<T> rather than weak_ptr, eliminating the need for the weak_ptr exception, allowing it to be deleted.
- Fixed various edge cases in pointer handling and ownership semantics