### PR TITLE
:bug: Fix support for arm-gcc-14.2 on stm32f103c8

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -85,6 +85,7 @@ class strong_ptr_conan(ConanFile):
         self._validate_compiler_version()
 
     def build_requirements(self):
+        self.tool_requires("cmake-modules-toolchain/1.0.1")
         self.tool_requires("cmake/4.1.1")
         self.tool_requires("ninja/1.13.1")
         self.test_requires("boost-ext-ut/2.3.1",
@@ -99,7 +100,6 @@ class strong_ptr_conan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generator = "Ninja"
-        tc.cache_variables["CMAKE_CXX_SCAN_FOR_MODULES"] = True
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 4.0)
 
 # Generate compile commands for anyone using our libraries.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 project(test_package LANGUAGES CXX)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -25,7 +25,7 @@ class TestPackageConan(ConanFile):
     generators = "VirtualRunEnv"
 
     def build_requirements(self):
-        self.tool_requires("cmake-modules-toolchain/1.0.0")
+        self.tool_requires("cmake-modules-toolchain/1.0.1")
         self.tool_requires("cmake/4.1.1")
         self.tool_requires("ninja/1.13.1")
 
@@ -35,7 +35,7 @@ class TestPackageConan(ConanFile):
     def layout(self):
         cmake_layout(self)
 
-    def inject_linker_flags(flags: str,  tc: CMakeToolchain) -> str:
+    def inject_linker_flags(self, flags: str,  tc: CMakeToolchain) -> str:
         link_flags = tc.variables.get("CMAKE_EXE_LINKER_FLAGS", "")
         link_flags = link_flags + f" {flags}"
         link_flags = link_flags.strip()
@@ -49,7 +49,7 @@ class TestPackageConan(ConanFile):
         if not should_add_flags:
             return
 
-        LIB_C_FLAGS = "--specs=nano.specs --specs=nosys.specs"
+        LIB_C_FLAGS = "--specs=nano.specs --specs=nosys.specs -mthumb"
         self.output.info(f"Baremetal ARM GCC Profile detected!")
         self.output.info(f'💉 injecting flags >> "{LIB_C_FLAGS}"')
         result = self.inject_linker_flags(LIB_C_FLAGS, tc)

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -12,23 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import std;
+#include <cassert>
+
+#include <memory_resource>
+
 import strong_ptr;
 
 int main()
 {
   auto ptr = mem::make_strong_ptr<int>(std::pmr::new_delete_resource(), 42);
-  std::println("[ptr](use_count = {}) = {}", ptr.use_count(), *ptr);
+  assert(*ptr == 42);
+  assert(ptr.use_count() == 1);
   {
-    std::println("\n{{");
     mem::optional_ptr<int> ptr2 = ptr;
-    std::println("  optional_ptr<int> created!");
-    std::println("  [ptr2](use_count = {}) = {}", ptr2.use_count(), *ptr2);
-    std::println("  [ptr](use_count = {}) = {}", ptr.use_count(), *ptr);
-    std::println("  optional_ptr<int> destroyed!");
-    std::println("}}\n");
+    assert(*ptr2 == 42);
+    *ptr2 = 55;
+    assert(*ptr2 == 55);
+    assert(ptr.use_count() == 2);
+    assert(ptr2.use_count() == 2);
   }
 
-  std::println("[ptr](use_count = {}) = {}", ptr.use_count(), *ptr);
+  assert(ptr.use_count() == 1);
+  assert(*ptr == 55);
   return 0;
 }


### PR DESCRIPTION
- Remove `import.std`` which needs GCC 15
- Remove `println` which trips up GCC's LTO
- Use asserts instead of `println`
- Replace default initialized atomics with constructor assigned values
  to allow stm32f103c8 and arm-gcc-14.2 to link