### PR TITLE
:bug: Add missing CMAKE_CXX_SCAN_FOR_MODULES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 4.0)
 # Generate compile commands for anyone using our libraries.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
+set(CMAKE_CXX_SCAN_FOR_MODULES ON)
 
 project(strong_ptr LANGUAGES CXX)
 


### PR DESCRIPTION
LLVM and gnu toolchains will no longer automatically enable this option and thus we must enable it on each cmake project.